### PR TITLE
Add sorting for Crop Finder neighbors table

### DIFF
--- a/TravianResourceBarPlus/TravianResourceBarPlus.user.js
+++ b/TravianResourceBarPlus/TravianResourceBarPlus.user.js
@@ -7700,16 +7700,48 @@ function cropFind () {
 				if( dA > dB ) return 1;
 				return 0;
 			});
-		var newT = $e('TABLE',[['id','reportWrapper'],['class',allIDs[7]],['style','width:100%;']]);
-		if (neFL) {
-			var tHead = $ee('THEAD',$em('TR',[$c(''),$c(''),$c(''),$c(trImg('iExperience'),[['class','body']]),$c($em('div',[$e('i',[['class','resources_small']]),"/",trImg('def1')]),[['style','width:52px']]),$c(''),$c(''),$c('<->')]));
-		} else {
-			var tHead = $ee('THEAD',$em('TR',[$c(''),$c(''),$c(''),$c('<->')]));
-		}
-		var tBody = $ee('THEAD');
-		newT.appendChild(tHead);
-		newT.appendChild(tBody);
-		oasis.sort(function(a,b){return parseInt(b[2])-parseInt(a[2]);});
+                var newT = $e('TABLE',[['id','reportWrapper'],['class',allIDs[7]],['style','width:100%;']]);
+                if (neFL) {
+                        var xpH = $a(trImg('iExperience'),[['href',jsVoid]]);
+                        var rdH = $a($em('div',[$e('i',[['class','resources_small']]),"/",trImg('def1')]),[['href',jsVoid]]);
+                        var tHead = $ee('THEAD',$em('TR',[
+                                $c(''),
+                                $c(''),
+                                $c(''),
+                                $c(xpH,[['class','body']]),
+                                $c(rdH,[['style','width:52px']]),
+                                $c(''),
+                                $c(''),
+                                $c('<->')
+                        ]));
+                } else {
+                        var tHead = $ee('THEAD',$em('TR',[$c(''),$c(''),$c(''),$c('<->')]));
+                }
+                var tBody = $ee('THEAD');
+                newT.appendChild(tHead);
+                newT.appendChild(tBody);
+
+                var lastSD = 0;
+                var lastSC = -1;
+                function sortNeighbors(sc){
+                        var nArr = [];
+                        for(var i=0;i<tBody.rows.length;i++){
+                                var val = parseFloat(tBody.rows[i].cells[sc].textContent.replace(/[^0-9.,-]/g,'').replace(',', '.'));
+                                if(isNaN(val)) val = Infinity;
+                                nArr[i] = [val,tBody.rows[i]];
+                        }
+                        if(lastSC==sc) lastSD = 1 - lastSD; else { lastSC = sc; lastSD = 0; }
+                        nArr.sort(function(a,b){return a[0]-b[0];});
+                        if(lastSD) nArr.reverse();
+                        for(var i=0;i<nArr.length;i++) tBody.appendChild(nArr[i][1]);
+                }
+
+                if(neFL){
+                        xpH.addEventListener('click',function(){sortNeighbors(3);},false);
+                        rdH.addEventListener('click',function(){sortNeighbors(4);},false);
+                }
+
+                oasis.sort(function(a,b){return parseInt(b[2])-parseInt(a[2]);});
 		for( var i=0; i<aCCs.length; i++ ) {
 			if( neFL ) {
 				tBody.appendChild($em('TR',[


### PR DESCRIPTION
## Summary
- make XP and res/def columns clickable in crop finder results
- add `sortNeighbors()` helper to sort rows
- allow sorting XP and ratio columns

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849bd59f93c832f87e0c41c1883f2f7