### PR TITLE
Add wave scheduling support

### DIFF
--- a/TravianWaveBuilder/TravianWaveBuilder.user.js
+++ b/TravianWaveBuilder/TravianWaveBuilder.user.js
@@ -350,12 +350,18 @@ sendBtn.removeAttribute('name');
 sendBtn.removeAttribute('id');
 sendBtn.addEventListener('click',sendWaves,false);
 
+var scheduleBtn = $g('ok').cloneNode(true);
+scheduleBtn.removeAttribute('name');
+scheduleBtn.removeAttribute('id');
+scheduleBtn.value = 'Send later';
+scheduleBtn.addEventListener('click',function(){ if (typeof scheduleWave === 'function') scheduleWave(); },false);
+
 var interval = $e('INPUT',[['type','text'],['value',defInterval],['title',langStrings[5]],['size',4],['maxlength',4],['style','text-align:right']]);
 var intervaltxt = $ee('SPAN',langStrings[7],[['style','display:inline-block;padding:0 5px;']]);
 var unitTimetxt = $ee('SPAN',langStrings[8],[['style','display:inline-block;padding:0 5px;']]);
-tbl.appendChild($ee('TFOOT',$ee('TR',$em('TD',[intervaltxt,interval,unitTimetxt,sendBtn,
-	$a(' (v'+version+') ',[['href',scriptURL],['target','_blank']])],
-	[['colspan',13],['style','background-color: transparent;text-align:center !important;padding:3px;']]))));
+tbl.appendChild($ee('TFOOT',$ee('TR',$em('TD',[intervaltxt,interval,unitTimetxt,sendBtn,scheduleBtn,
+        $a(' (v'+version+') ',[['href',scriptURL],['target','_blank']])],
+        [['colspan',13],['style','background-color: transparent;text-align:center !important;padding:3px;']]))));
 
 build.appendChild(tbl);
 


### PR DESCRIPTION
## Summary
- extend tasks with new "Send Wave" option and translations
- add scheduling button in WaveBuilder to queue waves
- implement scheduling logic and wave sending task in TaskQueue
- integrate with task list and task trigger logic

## Testing
- `node --check TravianTaskQueue/TravianTaskQueue.user.js`
- `node --check TravianWaveBuilder/TravianWaveBuilder.user.js`


------
https://chatgpt.com/codex/tasks/task_e_684b8f999e74832f973ca5388050ef56